### PR TITLE
Add linting of no-only-tests for lowercase "describe" and "context" style tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Include lowercase `describe` and `context` blocks in `no-only-tests/no-only-tests`.
+
 ## 1.1.0
 
 - Add rule `react/jsx-curly-spacing` to align jsx curly with js curly.

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ module.exports = {
     // no only in tests
     "no-only-tests/no-only-tests": [
       "error",
-      { block: [ "Feature", "Scenario", "it", "Describe", "describe" ] },
+      { block: [ "Feature", "Scenario", "it", "Describe", "describe", "context" ] },
     ],
     // chai friendly
     "no-unused-expressions": 0,

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ module.exports = {
     // no only in tests
     "no-only-tests/no-only-tests": [
       "error",
-      { block: [ "Feature", "Scenario", "it", "Describe" ] },
+      { block: [ "Feature", "Scenario", "it", "Describe", "describe" ] },
     ],
     // chai friendly
     "no-unused-expressions": 0,


### PR DESCRIPTION
When using `it` / `describe` / `context`-style tests (`context` is just an alias of `describe`), the rule for disallowing `.only` in tests was not active for the `describe` and `context` scopes.