### PR TITLE
Add a files pattern to the JS linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const baseConfig = require("./base-config");
+const jsConfig = require("./js");
 const jsxConfig = require("./jsx");
 const tsConfig = require("./ts");
 const tsxConfig = require("./tsx");
@@ -9,7 +9,7 @@ const testTsConfig = require("./test-ts");
 const ignoresConfig = require("./ignores");
 
 module.exports = [
-  baseConfig,
+  jsConfig,
   jsxConfig,
   tsConfig,
   tsxConfig,

--- a/js.js
+++ b/js.js
@@ -1,3 +1,8 @@
 "use strict";
 
-module.exports = require("./base-config");
+const baseConfig = require("./base-config");
+
+module.exports = {
+  ...baseConfig,
+  files: [ "**/*.js" ],
+};


### PR DESCRIPTION
Added a `files`-pattern represented as `**/*.js` to the js.js config file, and exposed that as the jsConfig choice rather than `baseConfig`. 

This prevents a situation where eslint 9.6+ is used for linting other languages, and then fails due to the `baseConfig` assuming that all files are JS by default. Potentially a breaking change? Not sure.