### PR TITLE
Update to ES module

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,6 +3,6 @@
   "reporter": "spec",
   "recursive": true,
   "ui": "mocha-cakes-2",
-  "require": ["./test/helpers/setup.js"],
+  "require": ["./test/helpers/setup.mjs"],
   "exit": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 3.0.0
+
+- Updated all dependencies to latest versions:
+  - `@bonniernews/eslint-plugin-typescript-rules` to ^1.0.2
+  - `@stylistic/eslint-plugin` to ^5.6.1
+  - `@typescript-eslint/eslint-plugin` to ^8.51.0
+  - `@typescript-eslint/parser` to ^8.51.0
+  - `eslint-plugin-chai-friendly` to ^1.1.0
+  - `eslint-plugin-import` to ^2.32.0
+  - `eslint-plugin-n` to ^17.23.1
+  - `eslint-plugin-react` to ^7.37.5
+  - `globals` to ^17.0.0
+  - `chai` to ^6.2.2 (dev)
+  - `eslint` to ^9.39.2 (dev)
+  - `mocha` to ^11.7.5 (dev)
+  - `typescript` to ^5.9.3 (dev)
+- Fixed ES module compatibility issues with dependencies:
+  - Converted `ts.js`, `tsx.js`, `test-ts.js`, and `index.js` to use async exports for `@stylistic/eslint-plugin` (ES module)
+  - Converted test setup to ES modules (`test/helpers/setup.mjs`) for compatibility with `chai` v6
+  - Updated `.mocharc.json` to reference the new ES module setup file
+  - Added `test/helpers/` to ESLint ignore patterns
+
+**Breaking change:** The TypeScript-related configs (`ts`, `tsx`, `test-ts`, and the main `index`) now export Promises due to ES module dependencies. ESLint handles this automatically when you use the standard `module.exports = require('@bonniernews/eslint-config/ts')` pattern. However, if you were manually spreading these configs (e.g., `...require('@bonniernews/eslint-config/ts')`), you'll need to await them first or restructure to avoid spreading.
+
+**Dependency updates impact:**
+- **@stylistic/eslint-plugin (v3 → v5)**: The major version updates were for packaging changes (removing sub-packages), not rule behavior. This package only uses the `@stylistic/no-extra-semi` rule, which has not changed behavior.
+- **@typescript-eslint (8.22 → 8.51)**: Minor version bump with bug fixes and new optional rules. No changes to currently configured rules.
+- **globals (v15 → v17)**: Minor version bump adding more global variable definitions. Existing globals unchanged.
+- **Other plugins**: Bug fixes and minor improvements with no user-facing impact.
+
 ## 2.0.2
 
 - Fixed bad docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
   - Updated `.mocharc.json` to reference the new ES module setup file
   - Added `test/helpers/` to ESLint ignore patterns
 
-**Breaking change:** The TypeScript-related configs (`ts`, `tsx`, `test-ts`, and the main `index`) now export Promises due to ES module dependencies. ESLint handles this automatically when you use the standard `module.exports = require('@bonniernews/eslint-config/ts')` pattern. However, if you were manually spreading these configs (e.g., `...require('@bonniernews/eslint-config/ts')`), you'll need to await them first or restructure to avoid spreading.
+**Breaking change:** The TypeScript-related configs (`ts`, `tsx`, `test-ts`, and the main `index`) now export Promises due to ES module dependencies. ESLint handles this automatically when you use the standard `module.exports = require('@bonniernews/eslint-config/ts')` pattern. However, if you were manually spreading these configs (e.g., `...require('@bonniernews/eslint-config/ts')`), you'll need to await them first or restructure to avoid spreading. See [README](./README.md#migrating-from-2x-to-3x) for details.
 
 **Dependency updates impact:**
 - **@stylistic/eslint-plugin (v3 → v5)**: The major version updates were for packaging changes (removing sub-packages), not rule behavior. This package only uses the `@stylistic/no-extra-semi` rule, which has not changed behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,10 @@
   - `eslint` to ^9.39.2 (dev)
   - `mocha` to ^11.7.5 (dev)
   - `typescript` to ^5.9.3 (dev)
-- Fixed ES module compatibility issues with dependencies:
-  - Converted `ts.js`, `tsx.js`, `test-ts.js`, and `index.js` to use async exports for `@stylistic/eslint-plugin` (ES module)
-  - Converted test setup to ES modules (`test/helpers/setup.mjs`) for compatibility with `chai` v6
-  - Updated `.mocharc.json` to reference the new ES module setup file
-  - Added `test/helpers/` to ESLint ignore patterns
+- Converted package to ESM (`"type": "module"`); all configs use `import`/`export default`.
+- Converted test setup to ESM (`test/helpers/setup.mjs`) for `chai` v6 compatibility; updated `.mocharc.json` accordingly.
 
-**Breaking change:** The TypeScript-related configs (`ts`, `tsx`, `test-ts`, and the main `index`) now export Promises due to ES module dependencies. ESLint handles this automatically when you use the standard `module.exports = require('@bonniernews/eslint-config/ts')` pattern. However, if you were manually spreading these configs (e.g., `...require('@bonniernews/eslint-config/ts')`), you'll need to await them first or restructure to avoid spreading. See [README](./README.md#migrating-from-2x-to-3x) for details.
+**Breaking change:** This package is now published as an ES Module. CommonJS projects must switch from `require` to `await import`. See [README](./README.md#migrating-from-2x-to-3x).
 
 **Dependency updates impact:**
 - **@stylistic/eslint-plugin (v3 → v5)**: The major version updates were for packaging changes (removing sub-packages), not rule behavior. This package only uses the `@stylistic/no-extra-semi` rule, which has not changed behavior.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For Node versions that support it (version 16 and above), the `es2022` environme
     - [Typed react configuration](#typed-react-configuration)
     - [Global ignores](#global-ignores)
     - [Globals](#globals)
+  - [Migrating from 2.X to 3.X](#migrating-from-2x-to-3x)
   - [Migrating from 1.X to 2.X](#migrating-from-1x-to-2x)
   - [Running eslint](#running-eslint)
   - [Usage in an existing project](#usage-in-an-existing-project)
@@ -116,7 +117,7 @@ To activate this config (in addition to other config(s), using it alone makes no
 ```javascript
 "use strict";
 
-const ignores = require("@bonniernews/eslint-config/ignores");
+const ignores = await require("@bonniernews/eslint-config/ignores");
 
 module.exports = [
   ...allYourGoodConfigs,
@@ -131,12 +132,40 @@ Globals for browsers, etc. that may be needed.
 ```javascript
 "use strict";
 
-const globals = require("@bonniernews/eslint-config/globals");
+const config = await require("@bonniernews/eslint-config");
 
 module.exports = [
   ...allYourGoodConfigs,
   { files: [ "assets/scripts" ], languageOptions: { globals: globals.browser } }
 ];
+```
+
+## Migrating from 2.X to 3.X
+
+Due to differences between ES modules and CommonJS, the TypeScript-related configs (`ts`, `tsx`, `test-ts`, and the main `index`).
+ESLint handles this automatically when you use the standard `module.exports = require('@bonniernews/eslint-config/ts')`, but if you need to extend the rules, you will need to add `await`s:
+
+
+```javascript
+"use strict";
+
+const config = await require("@bonniernews/eslint-config");
+
+module.exports = [
+  ...config,
+  { ignores: [ "dist/**" ] },
+]
+```
+
+or if using ES modules
+
+```javascript
+import config from "@bonniernews/eslint-config";
+
+export default [
+  ...(await config),
+  { ignores: [ "dist/**" ] },
+]
 ```
 
 ## Migrating from 1.X to 2.X

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ and the appropriate setup will be used by looking at the projects `package.json`
 
 For Node versions that support it (version 16 and above), the `es2022` environment will also be activated. Otherwise `es2021` will be used.
 
+> **Note:** As of version 3.X, this package is published as an ES Module. See the [usage examples](#usage) for how to use it in both ESM and CommonJS projects.
+
 ## Table of contents
 
 - [@bonniernews/eslint-config](#bonniernewseslint-config)
@@ -42,72 +44,80 @@ npm install --save-dev eslint @bonniernews/eslint-config
 
 Configures all rules, js, ts, tsx, jsx and test rules.
 
-To activate the config, you need to add the following to your `eslint.config.js`-file:
+**ESM** - for projects with `"type": "module"` in `package.json`:
 
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config";
 
-module.exports = require("@bonniernews/eslint-config");
+export default config;
+```
+
+**CommonJS** - for projects without `"type": "module"`:
+
+```javascript
+// eslint.config.js
+const { default: config } = await import("@bonniernews/eslint-config");
+
+module.exports = config;
 ```
 
 ### JavaScript configuration
 
-To activate the config, you need to add the following to your `eslint.config.js`-file:
-
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config/js";
 
-module.exports = require("@bonniernews/eslint-config/js");
+export default [ config ];
 ```
 
 ### TypeScript configuration
 
-To activate the config, you need to add the following to your `eslint.config.js`-file:
-
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config/ts";
 
-module.exports = require("@bonniernews/eslint-config/ts");
+export default [ config ];
 ```
 
 ### React configuration
 
-To activate the config, you need to add the following to your `eslint.config.js`-file:
-
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config/jsx";
 
-module.exports = require("@bonniernews/eslint-config/jsx");
+export default [ config ];
 ```
 
 ### Test configuration
 
 Adds useful plugins and globals for testing with mocha-cakes-2 + chai.
 
-To activate the config, you need to add the following to your `eslint.config.js`-file (for js):
+For JavaScript tests:
 
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config/test-js";
 
-module.exports = require("@bonniernews/eslint-config/test-js");
+export default [ config ];
 ```
 
-or the following (for ts):
+For TypeScript tests:
 
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config/test-ts";
 
-module.exports = require("@bonniernews/eslint-config/test-ts");
+export default [ config ];
 ```
 
 ### Typed react configuration
 
-To activate the config, you need to add the following to your `eslint.config.js`-file:
-
 ```javascript
-"use strict";
+// eslint.config.js
+import config from "@bonniernews/eslint-config/tsx";
 
-module.exports = require("@bonniernews/eslint-config/tsx");
+export default [ config ];
 ```
 
 ### Global ignores
@@ -115,13 +125,13 @@ module.exports = require("@bonniernews/eslint-config/tsx");
 To activate this config (in addition to other config(s), using it alone makes no sense), add the following:
 
 ```javascript
-"use strict";
+// eslint.config.js
+import ignores from "@bonniernews/eslint-config/ignores";
 
-const ignores = await require("@bonniernews/eslint-config/ignores");
-
-module.exports = [
+export default [
   ...allYourGoodConfigs,
-  ignores
+  ignores,
+  // your additional config
 ];
 ```
 
@@ -130,26 +140,33 @@ module.exports = [
 Globals for browsers, etc. that may be needed.
 
 ```javascript
-"use strict";
+// eslint.config.js
+import globals from "@bonniernews/eslint-config/globals";
 
-const config = await require("@bonniernews/eslint-config");
-
-module.exports = [
+export default [
   ...allYourGoodConfigs,
-  { files: [ "assets/scripts" ], languageOptions: { globals: globals.browser } }
+  { files: [ "assets/scripts/**/*.js" ], languageOptions: { globals: globals.browser } },
 ];
 ```
 
 ## Migrating from 2.X to 3.X
 
-Due to differences between ES modules and CommonJS, the TypeScript-related configs (`ts`, `tsx`, `test-ts`, and the main `index`).
-ESLint handles this automatically when you use the standard `module.exports = require('@bonniernews/eslint-config/ts')`, but if you need to extend the rules, you will need to add `await`s:
+Version 3.X is published as an ES Module (ESM).
 
+### For ESM projects using `import`
+
+If your project has `"type": "module"` in `package.json`, and you're already using `import`, then you don't have to make any changes.
+
+### For CommonJS projects using `require`
+
+If your project does not have `"type": "module"`, you need to use dynamic `import()` to import an ESM module, which is an asynchronous function:
+
+**Before (2.X):**
 
 ```javascript
 "use strict";
 
-const config = await require("@bonniernews/eslint-config");
+const config = require("@bonniernews/eslint-config");
 
 module.exports = [
   ...config,
@@ -157,13 +174,13 @@ module.exports = [
 ]
 ```
 
-or if using ES modules
+**After (3.X):**
 
 ```javascript
-import config from "@bonniernews/eslint-config";
+const { default: config } = await import("@bonniernews/eslint-config");
 
-export default [
-  ...(await config),
+module.exports = [
+  ...config,
   { ignores: [ "dist/**" ] },
 ]
 ```
@@ -214,7 +231,7 @@ npx eslint .
 - Remove any 'eslint-disable-line no-unused-expressions' directives added because of chai assertions, they are not
   needed anymore (`eslint-plugin-chai-friendly` is used in test).
 - Remove any globals and special rules related to `mocha-cakes-2` in your test configuration, they already exist
-  in the `@bonniernews/eslint-config/test` and `@bonniernews/eslint-config/all` configs.
+  in the `@bonniernews/eslint-config/test-js` and `@bonniernews/eslint-config/test-ts` configs.
 
 Once you complete the steps above run the following:
 
@@ -227,7 +244,7 @@ npx eslint . --fix
 If you want to use _Prettier_, run it before eslint. ESLint should be the final judge, i.e. run:
 
 ```sh
-npx prettier --save .
+npx prettier --write .
 npx eslint . --fix
 ```
 

--- a/base-config.js
+++ b/base-config.js
@@ -1,13 +1,15 @@
-"use strict";
+import fs from "fs";
+import { createRequire } from "module";
+import path from "path";
 
-const path = require("path");
-const fs = require("fs");
-const getRules = require("./rules");
-const globals = require("./globals");
+import eslintPluginTypescriptRules from "@bonniernews/eslint-plugin-typescript-rules";
+import eslintPluginImport from "eslint-plugin-import";
+import eslintPluginN from "eslint-plugin-n";
 
-const eslintPluginN = require("eslint-plugin-n");
-const eslintPluginImport = require("eslint-plugin-import");
-const eslintPluginTypescriptRules = require("@bonniernews/eslint-plugin-typescript-rules");
+import globals from "./globals.js";
+import getRules from "./rules.js";
+
+const require = createRequire(import.meta.url);
 
 function findPackageJson() {
   let dir = process.cwd();
@@ -63,4 +65,4 @@ const baseConfig = {
   rules: getRules(isModuleProject),
 };
 
-module.exports = baseConfig;
+export default baseConfig;

--- a/base-config.js
+++ b/base-config.js
@@ -1,10 +1,9 @@
-import fs from "fs";
-import { createRequire } from "module";
-import path from "path";
-
 import eslintPluginTypescriptRules from "@bonniernews/eslint-plugin-typescript-rules";
 import eslintPluginImport from "eslint-plugin-import";
 import eslintPluginN from "eslint-plugin-n";
+import fs from "fs";
+import { createRequire } from "module";
+import path from "path";
 
 import globals from "./globals.js";
 import getRules from "./rules.js";
@@ -32,6 +31,7 @@ function findPackageJson() {
   return null;
 }
 
+// eslint-disable-next-line import/no-dynamic-require
 const isModuleProject = require(findPackageJson()).type === "module";
 const hasES2022Support = parseInt(process.versions.node.split(".").shift(), 10) >= 16;
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,11 @@
 "use strict";
 
-module.exports = [
-  { ignores: [ "test/data/**/*" ] },
-  ...require("./index.js"),
-];
+const configPromise = require("./index.js");
+
+module.exports = (async () => {
+  const config = await configPromise;
+  return [
+    { ignores: [ "test/data/**/*", "test/helpers/**/*" ] },
+    ...config,
+  ];
+})();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,11 +1,6 @@
-"use strict";
+import config from "./index.js";
 
-const configPromise = require("./index.js");
-
-module.exports = (async () => {
-  const config = await configPromise;
-  return [
-    { ignores: [ "test/data/**/*", "test/helpers/**/*" ] },
-    ...config,
-  ];
-})();
+export default [
+  { ignores: [ "test/data/**/*", "test/helpers/**/*" ] },
+  ...config,
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import config from "./index.js";
 
 export default [
-  { ignores: [ "test/data/**/*", "test/helpers/**/*" ] },
+  { ignores: [ "test/data/**/*", "test/helpers/**/*", "test/commonjs/**/*" ] },
   ...config,
 ];

--- a/globals.js
+++ b/globals.js
@@ -1,3 +1,3 @@
-"use strict";
+import globals from "globals";
 
-module.exports = require("globals");
+export default globals;

--- a/ignores.js
+++ b/ignores.js
@@ -1,5 +1,4 @@
-"use strict";
-module.exports = {
+export default {
   ignores: [
     "tmp/",
     "public/",

--- a/index.js
+++ b/index.js
@@ -1,25 +1,17 @@
-"use strict";
+import baseConfig from "./base-config.js";
+import ignoresConfig from "./ignores.js";
+import jsxConfig from "./jsx.js";
+import testJsConfig from "./test-js.js";
+import testTsConfig from "./test-ts.js";
+import tsConfig from "./ts.js";
+import tsxConfig from "./tsx.js";
 
-const baseConfig = require("./base-config");
-const jsxConfig = require("./jsx");
-const tsConfigPromise = require("./ts");
-const tsxConfigPromise = require("./tsx");
-const testJsConfig = require("./test-js");
-const testTsConfigPromise = require("./test-ts");
-const ignoresConfig = require("./ignores");
-
-module.exports = (async () => {
-  const tsConfig = await tsConfigPromise;
-  const tsxConfig = await tsxConfigPromise;
-  const testTsConfig = await testTsConfigPromise;
-
-  return [
-    baseConfig,
-    jsxConfig,
-    tsConfig,
-    tsxConfig,
-    testJsConfig,
-    testTsConfig,
-    ignoresConfig,
-  ];
-})();
+export default [
+  baseConfig,
+  jsxConfig,
+  tsConfig,
+  tsxConfig,
+  testJsConfig,
+  testTsConfig,
+  ignoresConfig,
+];

--- a/index.js
+++ b/index.js
@@ -2,18 +2,24 @@
 
 const baseConfig = require("./base-config");
 const jsxConfig = require("./jsx");
-const tsConfig = require("./ts");
-const tsxConfig = require("./tsx");
+const tsConfigPromise = require("./ts");
+const tsxConfigPromise = require("./tsx");
 const testJsConfig = require("./test-js");
-const testTsConfig = require("./test-ts");
+const testTsConfigPromise = require("./test-ts");
 const ignoresConfig = require("./ignores");
 
-module.exports = [
-  baseConfig,
-  jsxConfig,
-  tsConfig,
-  tsxConfig,
-  testJsConfig,
-  testTsConfig,
-  ignoresConfig,
-];
+module.exports = (async () => {
+  const tsConfig = await tsConfigPromise;
+  const tsxConfig = await tsxConfigPromise;
+  const testTsConfig = await testTsConfigPromise;
+
+  return [
+    baseConfig,
+    jsxConfig,
+    tsConfig,
+    tsxConfig,
+    testJsConfig,
+    testTsConfig,
+    ignoresConfig,
+  ];
+})();

--- a/js.js
+++ b/js.js
@@ -1,3 +1,3 @@
-"use strict";
+import baseConfig from "./base-config.js";
 
-module.exports = require("./base-config");
+export default baseConfig;

--- a/jsx.js
+++ b/jsx.js
@@ -1,10 +1,9 @@
-"use strict";
+import reactPlugin from "eslint-plugin-react";
 
-const reactPlugin = require("eslint-plugin-react");
-const reactRules = require("./react-rules");
-const baseConfig = require("./base-config");
+import baseConfig from "./base-config.js";
+import reactRules from "./react-rules.js";
 
-module.exports = {
+export default {
   ...baseConfig,
   files: [ "**/*.jsx" ],
   languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^9.39.2",
         "mocha": "^11.7.5",
         "mocha-cakes-2": "^3.3.0",
+        "preact": "^10.29.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -391,7 +392,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -622,7 +622,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1470,7 +1469,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3374,6 +3372,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
+      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4176,7 +4185,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -391,6 +391,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -621,6 +622,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1468,6 +1470,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4173,6 +4176,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,31 @@
 {
   "name": "@bonniernews/eslint-config",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/eslint-config",
-      "version": "2.0.5",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@bonniernews/eslint-plugin-typescript-rules": "^1.0.0",
-        "@stylistic/eslint-plugin": "^3.1.0",
-        "@typescript-eslint/eslint-plugin": "^8.22.0",
-        "@typescript-eslint/parser": "^8.22.0",
-        "eslint-plugin-chai-friendly": "^1.0.1",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-n": "^17.15.1",
+        "@bonniernews/eslint-plugin-typescript-rules": "^1.0.2",
+        "@stylistic/eslint-plugin": "^5.6.1",
+        "@typescript-eslint/eslint-plugin": "^8.51.0",
+        "@typescript-eslint/parser": "^8.51.0",
+        "eslint-plugin-chai-friendly": "^1.1.0",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-n": "^17.23.1",
         "eslint-plugin-no-only-tests": "^3.3.0",
-        "eslint-plugin-react": "^7.37.4",
-        "globals": "^15.15.0"
+        "eslint-plugin-react": "^7.37.5",
+        "globals": "^17.0.0"
       },
       "devDependencies": {
-        "chai": "^4.3.10",
-        "eslint": "^9.19.0",
-        "mocha": "^11.3.0",
+        "chai": "^6.2.2",
+        "eslint": "^9.39.2",
+        "mocha": "^11.7.5",
         "mocha-cakes-2": "^3.3.0",
-        "typescript": "^5.7.3"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18"
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@bonniernews/eslint-plugin-typescript-rules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bonniernews/eslint-plugin-typescript-rules/-/eslint-plugin-typescript-rules-1.0.0.tgz",
-      "integrity": "sha512-W3+zfQ7cbagtOVTEgebymuIVgYMEmLKEMJ65E1q0JJMwVg+oqAckFr62erNKq6At1HCwHKCvvM03F1xMGMhidQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bonniernews/eslint-plugin-typescript-rules/-/eslint-plugin-typescript-rules-1.0.2.tgz",
+      "integrity": "sha512-rOow7BMQ5kwcbpivsfLKGa2PuEimDBpeLdSZnrnJsw0MCyVV4DOFPxHParyHk8aRIjTyNqborVv+Ogy7FIBCLw==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
-      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.14.0",
@@ -148,7 +148,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.3",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -300,28 +300,29 @@
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
-      "integrity": "sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.6.1.tgz",
+      "integrity": "sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.13.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@typescript-eslint/types": "^8.47.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "estraverse": "^5.3.0",
-        "picomatch": "^4.0.2"
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.40.0"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -349,19 +350,19 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
-      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.51.0.tgz",
+      "integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/type-utils": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
-        "ignore": "^7.0.5",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/type-utils": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -371,8 +372,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "@typescript-eslint/parser": "^8.51.0",
+        "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -386,17 +387,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
-      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
+      "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
-        "debug": "^4.4.3"
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -406,19 +406,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
-      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.51.0.tgz",
+      "integrity": "sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.0",
-        "@typescript-eslint/types": "^8.56.0",
-        "debug": "^4.4.3"
+        "@typescript-eslint/tsconfig-utils": "^8.51.0",
+        "@typescript-eslint/types": "^8.51.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -432,13 +432,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
-      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.51.0.tgz",
+      "integrity": "sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0"
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
-      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.51.0.tgz",
+      "integrity": "sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -465,16 +465,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
-      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.51.0.tgz",
+      "integrity": "sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -484,14 +484,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
-      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.51.0.tgz",
+      "integrity": "sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -502,20 +502,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
-      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.51.0.tgz",
+      "integrity": "sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.0",
-        "@typescript-eslint/tsconfig-utils": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
-        "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
+        "@typescript-eslint/project-service": "8.51.0",
+        "@typescript-eslint/tsconfig-utils": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
+        "debug": "^4.3.4",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -565,15 +565,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
-      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.51.0.tgz",
+      "integrity": "sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==",
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -583,18 +583,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
-      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.51.0.tgz",
+      "integrity": "sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "eslint-visitor-keys": "^5.0.0"
+        "@typescript-eslint/types": "8.51.0",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -605,9 +605,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -617,11 +617,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -838,16 +837,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -878,9 +867,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -962,22 +951,13 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -993,19 +973,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1217,19 +1184,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1269,9 +1223,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1510,11 +1464,10 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
-      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1522,7 +1475,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.3",
+        "@eslint/js": "9.39.2",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1629,9 +1582,9 @@
       }
     },
     "node_modules/eslint-plugin-chai-friendly": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.0.1.tgz",
-      "integrity": "sha512-dxD/uz1YKJ8U4yah1i+V/p/u+kHRy3YxTPe2nJGqb5lCR+ucan/KIexfZ5+q4X+tkllyMe86EBbAkdlwxNy3oQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.1.0.tgz",
+      "integrity": "sha512-+T1rClpDdXkgBAhC16vRQMI5umiWojVqkj9oUTdpma50+uByCZM/oBfxitZiOkjMRlm725mwFfz/RVgyDRvCKA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1722,9 +1675,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "17.24.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
-      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "version": "17.23.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.23.1.tgz",
+      "integrity": "sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.5.0",
@@ -1745,6 +1698,18 @@
       },
       "peerDependencies": {
         "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-no-only-tests": {
@@ -2015,9 +1980,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -2099,16 +2064,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2179,7 +2134,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2219,9 +2173,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2248,9 +2202,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
+      "integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2670,6 +2624,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -2999,16 +2963,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -3057,29 +3011,30 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
-      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -3105,9 +3060,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3115,16 +3070,19 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
-      "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -3385,16 +3343,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3403,9 +3351,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4146,16 +4094,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -4231,11 +4169,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4351,9 +4288,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -4372,9 +4309,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@bonniernews/eslint-config",
   "version": "3.0.0",
   "description": "ESLint config",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "mocha && eslint ."

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^9.39.2",
     "mocha": "^11.7.5",
     "mocha-cakes-2": "^3.3.0",
+    "preact": "^10.29.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/eslint-config",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "description": "ESLint config",
   "main": "index.js",
   "scripts": {
@@ -20,11 +20,11 @@
   ],
   "contributors": [],
   "devDependencies": {
-    "chai": "^4.3.10",
-    "eslint": "^9.19.0",
-    "mocha": "^11.3.0",
+    "chai": "^6.2.2",
+    "eslint": "^9.39.2",
+    "mocha": "^11.7.5",
     "mocha-cakes-2": "^3.3.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "eslint": ">=9.19.0",
@@ -40,16 +40,16 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@bonniernews/eslint-plugin-typescript-rules": "^1.0.0",
-    "@stylistic/eslint-plugin": "^3.1.0",
-    "@typescript-eslint/eslint-plugin": "^8.22.0",
-    "@typescript-eslint/parser": "^8.22.0",
-    "eslint-plugin-chai-friendly": "^1.0.1",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-n": "^17.15.1",
+    "@bonniernews/eslint-plugin-typescript-rules": "^1.0.2",
+    "@stylistic/eslint-plugin": "^5.6.1",
+    "@typescript-eslint/eslint-plugin": "^8.51.0",
+    "@typescript-eslint/parser": "^8.51.0",
+    "eslint-plugin-chai-friendly": "^1.1.0",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-n": "^17.23.1",
     "eslint-plugin-no-only-tests": "^3.3.0",
-    "eslint-plugin-react": "^7.37.4",
-    "globals": "^15.15.0"
+    "eslint-plugin-react": "^7.37.5",
+    "globals": "^17.0.0"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "mocha && eslint ."
+    "test-esm": "mocha",
+    "test-cjs": "cd test/commonjs && mocha",
+    "test": "npm run test-esm && npm run test-cjs && eslint ."
   },
   "repository": {
     "type": "git",

--- a/react-rules.js
+++ b/react-rules.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const eslintReactRecommendedRules = {
   "react/display-name": 2,
   "react/jsx-key": 2,
@@ -24,7 +22,7 @@ const eslintReactRecommendedRules = {
   "react/require-render-return": 2,
 };
 
-module.exports = {
+export default {
   ...eslintReactRecommendedRules,
   "react/prop-types": 0,
   "react/jsx-first-prop-new-line": [ 2, "multiline" ],

--- a/rules.js
+++ b/rules.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const eslintRecommendedRules = {
   "constructor-super": "error",
   "for-direction": "error",
@@ -229,7 +227,7 @@ const importRules = {
   "import/newline-after-import": "error",
 };
 
-module.exports = function getRules(isModuleProject) {
+export default function getRules(isModuleProject) {
   return {
     ...eslintRecommendedRules,
     ...nodeRecommendedRules,

--- a/rules.js
+++ b/rules.js
@@ -282,4 +282,4 @@ export default function getRules(isModuleProject) {
     "object-curly-newline": [ "error", { multiline: true } ],
     "object-property-newline": [ "error", { allowAllPropertiesOnSameLine: true } ],
   };
-};
+}

--- a/test-base.js
+++ b/test-base.js
@@ -1,8 +1,7 @@
-"use strict";
+import chaiFriendly from "eslint-plugin-chai-friendly";
+import noOnlyTests from "eslint-plugin-no-only-tests";
 
-const noOnlyTests = require("eslint-plugin-no-only-tests");
-const chaiFriendly = require("eslint-plugin-chai-friendly");
-const globals = require("./globals");
+import globals from "./globals.js";
 
 const mochaCakes2Globals = {
   And: "readonly",
@@ -40,7 +39,7 @@ const mochaCakes2Rules = {
   ],
 };
 
-module.exports = {
+export default {
   languageOptions: { globals: { ...mochaCakes2Globals } },
   files: [ "**/test/**/*.js", "**/test/**/*.ts" ],
   plugins: {

--- a/test-js.js
+++ b/test-js.js
@@ -1,9 +1,7 @@
-"use strict";
+import baseConfig from "./base-config.js";
+import testBase from "./test-base.js";
 
-const baseConfig = require("./base-config");
-const testBase = require("./test-base");
-
-module.exports = {
+export default {
   ...baseConfig,
   ...testBase,
   rules: {

--- a/test-ts.js
+++ b/test-ts.js
@@ -1,22 +1,26 @@
 "use strict";
 
-const tsConfig = require("./ts");
+const tsConfigPromise = require("./ts");
 const testBase = require("./test-base");
 
-module.exports = {
-  ...tsConfig,
-  ...testBase,
-  languageOptions: {
-    ...tsConfig.languageOptions,
-    ...testBase.languageOptions,
-  },
-  rules: {
-    ...tsConfig.rules,
-    ...testBase.rules,
-  },
-  plugins: {
-    ...tsConfig.plugins,
-    ...testBase.plugins,
-  },
-  files: [ "**/test/**/*.ts" ],
-};
+module.exports = (async () => {
+  const tsConfig = await tsConfigPromise;
+
+  return {
+    ...tsConfig,
+    ...testBase,
+    languageOptions: {
+      ...tsConfig.languageOptions,
+      ...testBase.languageOptions,
+    },
+    rules: {
+      ...tsConfig.rules,
+      ...testBase.rules,
+    },
+    plugins: {
+      ...tsConfig.plugins,
+      ...testBase.plugins,
+    },
+    files: [ "**/test/**/*.ts" ],
+  };
+})();

--- a/test-ts.js
+++ b/test-ts.js
@@ -1,26 +1,20 @@
-"use strict";
+import testBase from "./test-base.js";
+import tsConfig from "./ts.js";
 
-const tsConfigPromise = require("./ts");
-const testBase = require("./test-base");
-
-module.exports = (async () => {
-  const tsConfig = await tsConfigPromise;
-
-  return {
-    ...tsConfig,
-    ...testBase,
-    languageOptions: {
-      ...tsConfig.languageOptions,
-      ...testBase.languageOptions,
-    },
-    rules: {
-      ...tsConfig.rules,
-      ...testBase.rules,
-    },
-    plugins: {
-      ...tsConfig.plugins,
-      ...testBase.plugins,
-    },
-    files: [ "**/test/**/*.ts" ],
-  };
-})();
+export default {
+  ...tsConfig,
+  ...testBase,
+  languageOptions: {
+    ...tsConfig.languageOptions,
+    ...testBase.languageOptions,
+  },
+  rules: {
+    ...tsConfig.rules,
+    ...testBase.rules,
+  },
+  plugins: {
+    ...tsConfig.plugins,
+    ...testBase.plugins,
+  },
+  files: [ "**/test/**/*.ts" ],
+};

--- a/test/commonjs/.mocharc.json
+++ b/test/commonjs/.mocharc.json
@@ -2,8 +2,8 @@
   "timeout": 10000,
   "reporter": "spec",
   "recursive": true,
-  "ignore": ["test/commonjs/**"],
+  "spec": "feature/**/*.mjs",
   "ui": "mocha-cakes-2",
-  "require": ["./test/helpers/setup.mjs"],
+  "require": ["../helpers/setup.mjs"],
   "exit": true
 }

--- a/test/commonjs/data/js/extends.js
+++ b/test/commonjs/data/js/extends.js
@@ -1,0 +1,18 @@
+"use strict";
+class Foo {
+  constructor(bar) {
+    this.bar = bar;
+  }
+}
+
+class Bar extends Foo {
+  foo(foo) {
+    this.bar = foo;
+  }
+}
+
+function fooer() {
+  return new Bar("test");
+}
+
+fooer();

--- a/test/commonjs/data/js/noerrors.js
+++ b/test/commonjs/data/js/noerrors.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function add(a, b) {
+  return a + b;
+}
+
+add(2, 3);

--- a/test/commonjs/feature/lint-js-feature.mjs
+++ b/test/commonjs/feature/lint-js-feature.mjs
@@ -1,0 +1,55 @@
+import { ESLint } from "eslint";
+
+Feature("linting js files (commonjs)", () => {
+  Scenario("js file passing lint rules", () => {
+    let eslint;
+    Given("we have an eslint instance with the base config", () => {
+      eslint = new ESLint({
+        overrideConfigFile: "../../js.js",
+        ignore: false,
+      });
+    });
+
+    let results;
+    When("we lint a folder", async () => {
+      results = await eslint.lintFiles([ "data/js/noerrors.js" ]);
+    });
+
+    Then("we should have linted the correct number of files", () => {
+      expect(results.length).to.eql(1);
+    });
+
+    And("one file should have no messages", () => {
+      expect(results[0].messages.length).to.eql(0, JSON.stringify(results[0].messages));
+    });
+  });
+
+  Scenario("js file does not pass, tries to extend class", () => {
+    let eslint;
+    Given("we have an eslint instance with the base config", () => {
+      eslint = new ESLint({
+        overrideConfigFile: "../../js.js",
+        ignore: false,
+      });
+    });
+
+    let results;
+    When("we lint a file which extends a class", async () => {
+      results = await eslint.lintFiles([ "data/js/extends.js" ]);
+    });
+
+    Then("we should have linted the correct number of files", () => {
+      expect(results.length).to.eql(1);
+    });
+
+    And("one file should have errors", () => {
+      expect(results[0].messages.length).to.be.eql(1, JSON.stringify(results[0].messages));
+    });
+
+    And("one error should be because it extends a class", () => {
+      const error = results[0].messages.find(({ ruleId }) => ruleId === "@bonniernews/typescript-rules/disallow-class-extends");
+      expect(error).to.not.be.undefined;
+      expect(error.message).to.have.string("Extending");
+    });
+  });
+});

--- a/test/commonjs/package.json
+++ b/test/commonjs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "commonjs-test",
+  "private": true
+}

--- a/test/data/js/extends.js
+++ b/test/data/js/extends.js
@@ -1,4 +1,3 @@
-"use strict";
 class Foo {
   constructor(bar) {
     this.bar = bar;

--- a/test/data/js/noerrors.js
+++ b/test/data/js/noerrors.js
@@ -1,5 +1,3 @@
-"use strict";
-
 function add(a, b) {
   return a + b;
 }

--- a/test/feature/lint-js-feature.js
+++ b/test/feature/lint-js-feature.js
@@ -1,6 +1,4 @@
-"use strict";
-
-const { ESLint } = require("eslint");
+import { ESLint } from "eslint";
 
 Feature("linting js files", () => {
   Scenario("js file passing lint rules", () => {

--- a/test/feature/lint-jsx-feature.js
+++ b/test/feature/lint-jsx-feature.js
@@ -1,6 +1,4 @@
-"use strict";
-
-const { ESLint } = require("eslint");
+import { ESLint } from "eslint";
 
 Feature("linting jsx files", () => {
   Scenario("jsx file passing lint rules", () => {

--- a/test/feature/lint-tsx-feature.js
+++ b/test/feature/lint-tsx-feature.js
@@ -1,6 +1,4 @@
-"use strict";
-
-const { ESLint } = require("eslint");
+import { ESLint } from "eslint";
 
 Feature("linting tsx files", () => {
   Scenario("tsx file passing lint rules", () => {

--- a/test/feature/lint-typescript-feature.js
+++ b/test/feature/lint-typescript-feature.js
@@ -1,6 +1,4 @@
-"use strict";
-
-const { ESLint } = require("eslint");
+import { ESLint } from "eslint";
 
 Feature("linting ts files", () => {
   Scenario("ts file passing lint rules", () => {

--- a/test/helpers/setup.mjs
+++ b/test/helpers/setup.mjs
@@ -1,11 +1,7 @@
-"use strict";
+import "mocha-cakes-2";
+import * as chai from "chai";
 
 // Make sure dates are displayed in the correct timezone
-// Setup common test libraries
-require("mocha-cakes-2");
-
-const chai = require("chai");
-
 process.env.TZ = "Europe/Stockholm";
 
 // Tests should always run in test environment to prevent accidental deletion of

--- a/ts.js
+++ b/ts.js
@@ -1,29 +1,25 @@
-"use strict";
+import bnTypescriptRules from "@bonniernews/eslint-plugin-typescript-rules";
+import stylistic from "@stylistic/eslint-plugin";
+import typeScriptPlugin from "@typescript-eslint/eslint-plugin";
+import typeScriptParser from "@typescript-eslint/parser";
 
-const baseConfig = require("./base-config");
-const typescriptRules = require("./typescript-rules");
-const typeScriptPlugin = require("@typescript-eslint/eslint-plugin");
-const typeScriptParser = require("@typescript-eslint/parser");
-const bnTypescriptRules = require("@bonniernews/eslint-plugin-typescript-rules");
+import baseConfig from "./base-config.js";
+import typescriptRules from "./typescript-rules.js";
 
-module.exports = (async () => {
-  const stylistic = await import("@stylistic/eslint-plugin");
+const typescriptBase = {
+  plugins: {
+    ...baseConfig.plugins,
+    "@typescript-eslint": typeScriptPlugin,
+    "@stylistic": stylistic,
+    "@bonniernews/typescript-rules": bnTypescriptRules,
+  },
+  languageOptions: {
+    sourceType: "module",
+    parser: typeScriptParser,
+  },
+  files: [ "**/*.ts" ],
+  rules: { ...baseConfig.rules, ...typescriptRules },
+  settings: { "import/resolver": { node: { extensions: [ ".ts", ".js" ] } } },
+};
 
-  const typescriptBase = {
-    plugins: {
-      ...baseConfig.plugins,
-      "@typescript-eslint": typeScriptPlugin,
-      "@stylistic": stylistic.default,
-      "@bonniernews/typescript-rules": bnTypescriptRules,
-    },
-    languageOptions: {
-      sourceType: "module",
-      parser: typeScriptParser,
-    },
-    files: [ "**/*.ts" ],
-    rules: { ...baseConfig.rules, ...typescriptRules },
-    settings: { "import/resolver": { node: { extensions: [ ".ts", ".js" ] } } },
-  };
-
-  return typescriptBase;
-})();
+export default typescriptBase;

--- a/ts.js
+++ b/ts.js
@@ -4,23 +4,26 @@ const baseConfig = require("./base-config");
 const typescriptRules = require("./typescript-rules");
 const typeScriptPlugin = require("@typescript-eslint/eslint-plugin");
 const typeScriptParser = require("@typescript-eslint/parser");
-const stylistic = require("@stylistic/eslint-plugin");
 const bnTypescriptRules = require("@bonniernews/eslint-plugin-typescript-rules");
 
-const typescriptBase = {
-  plugins: {
-    ...baseConfig.plugins,
-    "@typescript-eslint": typeScriptPlugin,
-    "@stylistic": stylistic,
-    "@bonniernews/typescript-rules": bnTypescriptRules,
-  },
-  languageOptions: {
-    sourceType: "module",
-    parser: typeScriptParser,
-  },
-  files: [ "**/*.ts" ],
-  rules: { ...baseConfig.rules, ...typescriptRules },
-  settings: { "import/resolver": { node: { extensions: [ ".ts", ".js" ] } } },
-};
+module.exports = (async () => {
+  const stylistic = await import("@stylistic/eslint-plugin");
 
-module.exports = typescriptBase;
+  const typescriptBase = {
+    plugins: {
+      ...baseConfig.plugins,
+      "@typescript-eslint": typeScriptPlugin,
+      "@stylistic": stylistic.default,
+      "@bonniernews/typescript-rules": bnTypescriptRules,
+    },
+    languageOptions: {
+      sourceType: "module",
+      parser: typeScriptParser,
+    },
+    files: [ "**/*.ts" ],
+    rules: { ...baseConfig.rules, ...typescriptRules },
+    settings: { "import/resolver": { node: { extensions: [ ".ts", ".js" ] } } },
+  };
+
+  return typescriptBase;
+})();

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,8 @@
 import bnTypescriptRules from "@bonniernews/eslint-plugin-typescript-rules";
 import stylistic from "@stylistic/eslint-plugin";
+// eslint-disable-next-line import/no-unresolved
 import typeScriptPlugin from "@typescript-eslint/eslint-plugin";
+// eslint-disable-next-line import/no-unresolved
 import typeScriptParser from "@typescript-eslint/parser";
 
 import baseConfig from "./base-config.js";

--- a/tsx.js
+++ b/tsx.js
@@ -1,17 +1,12 @@
-"use strict";
+import reactPlugin from "eslint-plugin-react";
 
-const typescriptBasePromise = require("./ts");
-const reactPlugin = require("eslint-plugin-react");
-const reactRules = require("./react-rules");
+import reactRules from "./react-rules.js";
+import typescriptBase from "./ts.js";
 
-module.exports = (async () => {
-  const typescriptBase = await typescriptBasePromise;
-
-  return {
-    ...typescriptBase,
-    plugins: { ...typescriptBase.plugins, react: reactPlugin },
-    files: [ "**/*.tsx" ],
-    rules: { ...typescriptBase.rules, ...reactRules },
-    settings: { "import/resolver": { node: { extensions: [ ".ts", ".js", ".tsx", ".jsx" ] } } },
-  };
-})();
+export default {
+  ...typescriptBase,
+  plugins: { ...typescriptBase.plugins, react: reactPlugin },
+  files: [ "**/*.tsx" ],
+  rules: { ...typescriptBase.rules, ...reactRules },
+  settings: { "import/resolver": { node: { extensions: [ ".ts", ".js", ".tsx", ".jsx" ] } } },
+};

--- a/tsx.js
+++ b/tsx.js
@@ -1,13 +1,17 @@
 "use strict";
 
-const typescriptBase = require("./ts");
+const typescriptBasePromise = require("./ts");
 const reactPlugin = require("eslint-plugin-react");
 const reactRules = require("./react-rules");
 
-module.exports = {
-  ...typescriptBase,
-  plugins: { ...typescriptBase.plugins, react: reactPlugin },
-  files: [ "**/*.tsx" ],
-  rules: { ...typescriptBase.rules, ...reactRules },
-  settings: { "import/resolver": { node: { extensions: [ ".ts", ".js", ".tsx", ".jsx" ] } } },
-};
+module.exports = (async () => {
+  const typescriptBase = await typescriptBasePromise;
+
+  return {
+    ...typescriptBase,
+    plugins: { ...typescriptBase.plugins, react: reactPlugin },
+    files: [ "**/*.tsx" ],
+    rules: { ...typescriptBase.rules, ...reactRules },
+    settings: { "import/resolver": { node: { extensions: [ ".ts", ".js", ".tsx", ".jsx" ] } } },
+  };
+})();

--- a/typescript-rules.js
+++ b/typescript-rules.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const typescriptEslintRecommended = {
   "@typescript-eslint/adjacent-overload-signatures": "error",
   "@typescript-eslint/ban-ts-comment": "error",
@@ -55,7 +53,7 @@ const eslitRecommendedTs = {
 
 const importRules = { "import/named": "off" };
 
-module.exports = {
+export default {
   ...typescriptEslintRecommended,
   ...eslitRecommendedTs,
   ...importRules,


### PR DESCRIPTION
We want to bump all dependencies. Since one of them has updated to ESM only, we have to `import` it, either with a top level `import`, or a dynamic `import()`, which would then be async. Using `await import()` would require ALL consumers to `await` the config, so the option is to convert the whole project to ESM and use static `import`s, which is what we chose.