### PR TITLE
Update no-unused-vars rule to allow ignored args

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -54,7 +54,7 @@ const eslintRecommendedRules = {
   "no-unsafe-negation": "error",
   "no-unsafe-optional-chaining": "error",
   "no-unused-labels": "error",
-  "no-unused-vars": "error",
+  "no-unused-vars": [ "error", { args: "all", argsIgnorePattern: "^_" } ],
   "no-useless-backreference": "error",
   "no-useless-catch": "error",
   "no-useless-escape": "error",


### PR DESCRIPTION
Suggestion: do not allow an argument before the last argument to be unused. This enforces all parameters to be used.
Allowing to ignore the unused variable with `_`

```js
// Not allowed
function foo(a, b, c) { // 'b' is declared but its value is never read.
  console.log(a, c);
}

// Allowed
function foo(a, _b, c) {
  console.log(a, c);
}
```