### PR TITLE
Fix finding package.json function

### DIFF
--- a/base-config.js
+++ b/base-config.js
@@ -9,22 +9,28 @@ const eslintPluginN = require("eslint-plugin-n");
 const eslintPluginImport = require("eslint-plugin-import");
 const eslintPluginTypescriptRules = require("@bonniernews/eslint-plugin-typescript-rules");
 
-function findPackageJson(startDir) {
-  let dir = path.resolve(startDir || process.cwd());
+function findPackageJson() {
+  let dir = process.cwd();
+  const root = path.parse(dir).root;
 
-  do {
+  while (dir !== root) {
     const pkgfile = path.join(dir, "package.json");
 
-    if (!fs.existsSync(pkgfile)) {
-      dir = path.join(dir, "..");
-      continue;
+    if (fs.existsSync(pkgfile)) {
+      return pkgfile;
     }
-    return pkgfile;
-  } while (dir !== path.resolve(dir, "..") && !fs.existsSync(path.resolve(dir, ".git")));
+
+    if (fs.existsSync(path.join(dir, ".git"))) {
+      break;
+    }
+
+    dir = path.join(dir, "..");
+  }
+
   return null;
 }
 
-const isModuleProject = require(findPackageJson(fs.realpathSync(process.cwd()))).type === "module";
+const isModuleProject = require(findPackageJson()).type === "module";
 const hasES2022Support = parseInt(process.versions.node.split(".").shift(), 10) >= 16;
 
 const moduleConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/eslint-config",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/eslint-config",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/eslint-plugin-typescript-rules": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/eslint-config",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "ESLint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The previous version only worked if run from the same folder as the
`package.json` file, since it sets the directory to check to its parent
before checking if `.git` is present.

Also simplify and remove redundant things.
