### PR TITLE
Check against NPM instead of git tag when determining if we should release a new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Check if package version changed
         id: check_version
         run: |
+          name="$(cat package.json | jq -r '.name')"
           version="v$(cat package.json | jq -r '.version')"
-          if [ $(git tag -l "$version") ]; then
+          if npm view "$name@$version" &> /dev/null; then
             echo "Tag $version already exists."
           else
             echo "version_tag=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
If you bump using the command `npm version <major|minor|patch|...>`, it will automatically create a git tag, and if this is pushed, we won't release a new version. Let's check directly if the version exists on NPM, which is what actually matters.